### PR TITLE
Minor fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/bitbucket-pr-detector",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Perform configurable actions when new pull requests of interest are opened",
   "main": "dist/src/index.js",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export async function processPullRequestsAsync(
     bitbucketPRQuery = 'pullrequests?state=OPEN'
   } = config;
 
-  const prs = await gatherAPIValues(config, config.bitbucketPRQuery);
+  const prs = await gatherAPIValues(config, bitbucketPRQuery);
 
   debugLog(config, `found ${prs.length} open pull requests`);
 


### PR DESCRIPTION
Fixes scoped reference. Also 1.0.4 failed to build `/dist` before publishing.